### PR TITLE
Add MBTilesWriter initialize arguments for Geopaparazzi4

### DIFF
--- a/tilingthread.py
+++ b/tilingthread.py
@@ -103,7 +103,7 @@ class TilingThread(QThread):
         elif self.mode == 'ZIP':
             self.writer = ZipWriter(self.output, self.rootDir)
         elif self.mode == 'MBTILES':
-            self.writer = MBTilesWriter(self.output, self.rootDir)
+            self.writer = MBTilesWriter(self.output, self.rootDir,self.format,self.minZoom,self.maxZoom,self.extent)
         self.rangeChanged.emit(self.tr('Searching tiles...'), 0)
         useTMS = 1
         if self.tmsConvention:

--- a/writers.py
+++ b/writers.py
@@ -76,14 +76,23 @@ class ZipWriter:
 
 
 class MBTilesWriter:
-    def __init__(self, outputPath, rootDir):
+    def __init__(self, outputPath, rootDir, formatext, minZoom,maxZoom,extent):
         self.output = outputPath
         self.rootDir = rootDir
-
+        s = str(extent.xMinimum()) + ',' + str(extent.yMinimum()) + ',' + str(extent.xMaximum()) + ','+ str(extent.yMaximum())
         self.connection = mbtiles_connect(unicode(self.output.absoluteFilePath()))
         self.cursor = self.connection.cursor()
         optimize_connection(self.cursor)
         mbtiles_setup(self.cursor)
+        self.cursor.execute('''INSERT INTO metadata(name, value) VALUES (?, ?);''',('name',rootDir))
+        self.cursor.execute('''INSERT INTO metadata(name, value) VALUES (?, ?);''',('description',rootDir))
+        self.cursor.execute('''INSERT INTO metadata(name, value) VALUES (?, ?);''',('format',formatext))
+        self.cursor.execute('''INSERT INTO metadata(name, value) VALUES (?, ?);''',('minZoom',str(minZoom)))
+        self.cursor.execute('''INSERT INTO metadata(name, value) VALUES (?, ?);''',('maxZoom',str(maxZoom)))
+        self.cursor.execute('''INSERT INTO metadata(name, value) VALUES (?, ?);''',('type','baselayer'))
+        self.cursor.execute('''INSERT INTO metadata(name, value) VALUES (?, ?);''',('version','1.1'))
+        self.cursor.execute('''INSERT INTO metadata(name, value) VALUES (?, ?);''',('bounds',s))
+        self.connection.commit()
 
     def writeTile(self, tile, image, format, quality):
         data = QByteArray()


### PR DESCRIPTION
Add MBTilesWriter arguments  of format(ext), minZoom,maxZoom,extent to
store them into metadata table for Geopaparazzi4 MBtiles
