### PR TITLE
QTiles: implement option to not render empty tiles

### DIFF
--- a/qtilesdialog.py
+++ b/qtilesdialog.py
@@ -168,6 +168,7 @@ class QTilesDialog(QDialog, Ui_Dialog):
         self.chkWriteOverview.setChecked(self.settings.value("write_overview", False, type=bool))
         self.chkWriteMapurl.setChecked(self.settings.value("write_mapurl", False, type=bool))
         self.chkWriteViewer.setChecked(self.settings.value("write_viewer", False, type=bool))
+        self.chkRenderEmptyTiles.setChecked(self.settings.value("renderEmptyTiles", True, type=bool))
 
         self.formatChanged()
 
@@ -215,6 +216,7 @@ class QTilesDialog(QDialog, Ui_Dialog):
         self.settings.setValue('write_overview', self.chkWriteOverview.isChecked())
         self.settings.setValue('write_mapurl', self.chkWriteMapurl.isChecked())
         self.settings.setValue('write_viewer', self.chkWriteViewer.isChecked())
+        self.settings.setValue('renderEmptyTiles', self.chkRenderEmptyTiles.isChecked())
         canvas = self.iface.mapCanvas()
         if self.rbExtentCanvas.isChecked():
             extent = canvas.extent()
@@ -226,7 +228,7 @@ class QTilesDialog(QDialog, Ui_Dialog):
         extent = QgsCoordinateTransform(canvas.mapRenderer().destinationCrs(), QgsCoordinateReferenceSystem('EPSG:4326')).transform(extent)
         arctanSinhPi = math.degrees(math.atan(math.sinh(math.pi)))
         extent = extent.intersect(QgsRectangle(-180, -arctanSinhPi, 180, arctanSinhPi))
-        layers = canvas.mapSettings().layers()
+        layers = canvas.layers()
         writeMapurl = self.chkWriteMapurl.isEnabled() and self.chkWriteMapurl.isChecked()
         writeViewer = self.chkWriteViewer.isEnabled() and self.chkWriteViewer.isChecked()
         self.workThread = tilingthread.TilingThread(
@@ -246,6 +248,7 @@ class QTilesDialog(QDialog, Ui_Dialog):
             self.chkMBTilesCompression.isChecked(),
             self.chkWriteJson.isChecked(),
             self.chkWriteOverview.isChecked(),
+            self.chkRenderEmptyTiles.isChecked(),
             writeMapurl,
             writeViewer
         )

--- a/ui/qtilesdialogbase.ui
+++ b/ui/qtilesdialogbase.ui
@@ -47,9 +47,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>0</y>
-        <width>485</width>
-        <height>624</height>
+        <y>-162</y>
+        <width>508</width>
+        <height>787</height>
        </rect>
       </property>
       <property name="styleSheet">
@@ -412,6 +412,22 @@
           <property name="topMargin">
            <number>6</number>
           </property>
+          <item row="1" column="1">
+           <widget class="QSpinBox" name="spnTileHeight">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="minimum">
+             <number>128</number>
+            </property>
+            <property name="maximum">
+             <number>2048</number>
+            </property>
+            <property name="value">
+             <number>256</number>
+            </property>
+           </widget>
+          </item>
           <item row="0" column="0">
            <widget class="QLabel" name="label_3">
             <property name="text">
@@ -449,37 +465,7 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QSpinBox" name="spnTileHeight">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="minimum">
-             <number>128</number>
-            </property>
-            <property name="maximum">
-             <number>2048</number>
-            </property>
-            <property name="value">
-             <number>256</number>
-            </property>
-           </widget>
-          </item>
-          <item row="6" column="0" colspan="3">
-           <widget class="QCheckBox" name="chkAntialiasing">
-            <property name="text">
-             <string>Make lines appear less jagged at the expence of some drawing performance</string>
-            </property>
-           </widget>
-          </item>
-          <item row="7" column="0" colspan="3">
-           <widget class="QCheckBox" name="chkTMSConvention">
-            <property name="text">
-             <string>Use TMS tiles convention (Slippy Map by default)</string>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0" colspan="3">
+          <item row="11" column="0" colspan="3">
            <widget class="QCheckBox" name="chkMBTilesCompression">
             <property name="text">
              <string>Use MBTiles compression</string>
@@ -487,27 +473,41 @@
            </widget>
           </item>
           <item row="9" column="0" colspan="3">
+           <widget class="QCheckBox" name="chkTMSConvention">
+            <property name="text">
+             <string>Use TMS tiles convention (Slippy Map by default)</string>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0" colspan="3">
+           <widget class="QCheckBox" name="chkAntialiasing">
+            <property name="text">
+             <string>Make lines appear less jagged at the expence of some drawing performance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="12" column="0" colspan="3">
            <widget class="QCheckBox" name="chkWriteJson">
             <property name="text">
              <string>Write .json metadata</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="0" colspan="3">
+          <item row="13" column="0" colspan="3">
            <widget class="QCheckBox" name="chkWriteOverview">
             <property name="text">
              <string>Write overview image file</string>
             </property>
            </widget>
           </item>
-          <item row="11" column="0" colspan="3">
+          <item row="14" column="0" colspan="3">
            <widget class="QCheckBox" name="chkWriteMapurl">
             <property name="text">
              <string>Write .mapurl file</string>
             </property>
            </widget>
           </item>
-          <item row="12" column="0" colspan="3">
+          <item row="15" column="0" colspan="3">
            <widget class="QCheckBox" name="chkWriteViewer">
             <property name="text">
              <string>Write Leaflet-based viewer</string>
@@ -528,6 +528,13 @@
             </property>
            </widget>
           </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>Quality</string>
+            </property>
+           </widget>
+          </item>
           <item row="4" column="1">
            <widget class="QSpinBox" name="spnTransparency">
             <property name="maximum">
@@ -535,13 +542,6 @@
             </property>
             <property name="value">
              <number>255</number>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="label_7">
-            <property name="text">
-             <string>Quality</string>
             </property>
            </widget>
           </item>
@@ -577,6 +577,16 @@
               <string>JPG</string>
              </property>
             </item>
+           </widget>
+          </item>
+          <item row="10" column="0">
+           <widget class="QCheckBox" name="chkRenderEmptyTiles">
+            <property name="text">
+             <string>Render empty tiles</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
This patch give the option for users like me to not render 100% transparent tiles.

Example:
Without my patch, I have a raster covering France and a raster covering Japan, I choose 'Full extent' export and zoom 8-14 and transparency 255.
QTiles will generate 18 millions tiles where almost 80% are unused because I have no raster for Germany, Roumania, Russia, India, China..... so QTiles wille create 100% transparent PNG for those countries

With my patch, when the user uncheck the "Render empty tiles" checkbox, only 4 millions of tiles will be generated because my patch skip all countries where there is no raster.

The technique to achieve this is very simple: before adding the tile to the "tiles cues" I check if at least one of raster extent intercept the tile extent. 

I think this patch is also partly in relation to #56  

Best regards,