### PR TITLE
Conditional rendering on vector layer intersection

### DIFF
--- a/tile.py
+++ b/tile.py
@@ -46,3 +46,11 @@ class Tile:
 
     def toRectangle(self):
         return QgsRectangle(self.toPoint(), Tile(self.x + 1, self.y + 1, self.z, self.tms).toPoint())
+
+    # def intersects_spatial_index(self, spatial_index):
+    #     rectangle = self.toRectangle()
+    #     intersect = spatial_index.intersects(rectangle)
+    #     if intersect:
+    #         return True
+    #     else:
+    #         return False

--- a/tile.py
+++ b/tile.py
@@ -47,10 +47,8 @@ class Tile:
     def toRectangle(self):
         return QgsRectangle(self.toPoint(), Tile(self.x + 1, self.y + 1, self.z, self.tms).toPoint())
 
-    # def intersects_spatial_index(self, spatial_index):
-    #     rectangle = self.toRectangle()
-    #     intersect = spatial_index.intersects(rectangle)
-    #     if intersect:
-    #         return True
-    #     else:
-    #         return False
+    def intersects_spatial_index(self, spatial_index):
+        if spatial_index.intersects(self.toRectangle()):
+            return True
+        else:
+            return False

--- a/tilingthread.py
+++ b/tilingthread.py
@@ -103,6 +103,7 @@ class TilingThread(QThread):
             self.settings.setFlag(QgsMapSettings.Antialiasing, True)
         else:
             self.settings.setFlag(QgsMapSettings.DrawLabeling, True)
+        # self.spatialIndex = spatialIndex
 
     def run(self):
         self.mutex.lock()
@@ -135,7 +136,10 @@ class TilingThread(QThread):
             self.tiles = None
             self.processInterrupted.emit()
         self.rangeChanged.emit(self.tr('Rendering: %v from %m (%p%)'), len(self.tiles))
+        QgsMessageLog.logMessage(str(len(self.tiles)))
         for t in self.tiles:
+            # if not self.spatialIndex or t.intersects_spatial_index(self.spatialIndex):
+            #     self.render(t)
             self.render(t)
             self.updateProgress.emit()
             self.mutex.lock()

--- a/ui/qtilesdialogbase.ui
+++ b/ui/qtilesdialogbase.ui
@@ -49,7 +49,7 @@
         <x>0</x>
         <y>0</y>
         <width>515</width>
-        <height>619</height>
+        <height>607</height>
        </rect>
       </property>
       <property name="styleSheet">
@@ -277,20 +277,17 @@
           <string>Extent</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_2">
-          <property name="topMargin">
-           <number>6</number>
-          </property>
-          <item row="1" column="0">
-           <widget class="QRadioButton" name="rbExtentFull">
-            <property name="text">
-             <string>Full extent</string>
-            </property>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QRadioButton" name="rbExtentCanvas">
             <property name="text">
              <string>Canvas extent</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QRadioButton" name="rbExtentFull">
+            <property name="text">
+             <string>Full extent</string>
             </property>
            </widget>
           </item>
@@ -303,6 +300,23 @@
           </item>
           <item row="2" column="1">
            <widget class="QComboBox" name="cmbLayers">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QRadioButton" name="rbVectorIntersect">
+            <property name="text">
+             <string>Feature intersect</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QComboBox" name="cmbVectorIntersect">
             <property name="sizePolicy">
              <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
               <horstretch>0</horstretch>
@@ -402,10 +416,10 @@
          <property name="title">
           <string>Parameters</string>
          </property>
-         <property name="collapsed" stdset="0">
+         <property name="collapsed">
           <bool>true</bool>
          </property>
-         <property name="saveCollapsedState" stdset="0">
+         <property name="saveCollapsedState">
           <bool>true</bool>
          </property>
          <layout class="QGridLayout">
@@ -631,7 +645,7 @@
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
-   <header>qgis.gui</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
  </customwidgets>
@@ -644,8 +658,8 @@
    <slot>accept()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
+     <x>257</x>
+     <y>680</y>
     </hint>
     <hint type="destinationlabel">
      <x>157</x>
@@ -660,8 +674,8 @@
    <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
+     <x>325</x>
+     <y>680</y>
     </hint>
     <hint type="destinationlabel">
      <x>286</x>


### PR DESCRIPTION
This PR adds support for the specification of a vector layer in the "Extents" section of the dialogue.If this option is selected, only tiles that intersect this layer's features (not just the feature extents) are rendered. All other possible tiles are ignored. I use a `QgsSpatialIndex` to check intersection between `tile.toRectangle()` bounds and features in the specified layer, so it is very fast (tested against a 400MB global coastline shapefile, and again as a PostGIS layer.

An example of the benefit: I used a layer containing only the Autralian mainland as my vector intersection source lyer. Up to zoom 4, only 9 tiles are required, compared to 301 tiles without this additional option.

Let me know if something is not up to scratch.