### PR TITLE
switch from http to https for osm urls

### DIFF
--- a/resources/viewer.html
+++ b/resources/viewer.html
@@ -54,9 +54,9 @@
         })
 
       var map = L.map('map').setView([@centery, @centerx], @avgzoom);
-      var baselayer = L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      var baselayer = L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 18,
-        attribution: 'Map data &copy; <a href="//openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        attribution: 'Map data &copy; <a href="https://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       }).addTo(map);
 
       var mytile =L.tileLayer('file:///@tilesdir/{z}/{x}/{y}.@tilesext', {

--- a/resources/viewer.html
+++ b/resources/viewer.html
@@ -54,9 +54,9 @@
         })
 
       var map = L.map('map').setView([@centery, @centerx], @avgzoom);
-      var baselayer = L.tileLayer('http://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+      var baselayer = L.tileLayer('//{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
         maxZoom: 18,
-        attribution: 'Map data &copy; <a href="http://openstreetmap.org/copyright">OpenStreetMap</a> contributors'
+        attribution: 'Map data &copy; <a href="//openstreetmap.org/copyright">OpenStreetMap</a> contributors'
       }).addTo(map);
 
       var mytile =L.tileLayer('file:///@tilesdir/{z}/{x}/{y}.@tilesext', {


### PR DESCRIPTION
switch from http to // to allow seamless https usage. openstreetmap and its servers support https nowadays.